### PR TITLE
Remove unnecessary slice in flag.Source.

### DIFF
--- a/sources.go
+++ b/sources.go
@@ -143,8 +143,8 @@ func newSourceFlag(args []string) (*flag, error) {
 // stored at the specified key from the flag source.
 func (f *flag) Source(fld Field) (string, bool) {
 	if fld.Options.ShortFlagChar != 0 {
-		flagKey := []string{string(fld.Options.ShortFlagChar)}
-		k := strings.ToLower(strings.Join(flagKey, `-`))
+		flagKey := fld.Options.ShortFlagChar
+		k := strings.ToLower(string(flagKey))
 		if val, found := f.m[k]; found {
 			return val, found
 		}


### PR DESCRIPTION
With `fld.Options.ShortFlagChar` set, casting to a string is more
efficient than creating a one-element string slice and then calling
strings.Join on it.