### PR TITLE
adding feature to mask passwords, including passwords in URLs

### DIFF
--- a/conf_test.go
+++ b/conf_test.go
@@ -603,3 +603,45 @@ func TestVersionImplicit(t *testing.T) {
 		}
 	}
 }
+
+func TestMasking(t *testing.T) {
+	t.Log("Given the need mask passwords.")
+	{
+		//bar result string
+		t.Logf("\tTest: %d\tWhen setting `mask` for a url.", 1)
+		{
+			var result string
+			var cfg struct {
+				DebugHost string `conf:"default:http://user:password@0.0.0.0:4000,mask"`
+			}
+			if err := conf.Parse(nil, "APP", &cfg); err != nil {
+				t.Errorf("\tShould NOT receive an error : %s", err)
+				return
+			}
+			result, err := conf.String(&cfg)
+			if err != nil {
+				t.Errorf("\tShould NOT receive an error : %s", err)
+				return
+			}
+			got := strings.Trim(result, " \n")
+			want := `--debug-host=http://user:xxxxxx@0.0.0.0:4000`
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("\t%s\tShould match the output byte for byte. See diff:", failed)
+				t.Log(diff)
+			}
+			t.Logf("\t%s\tShould match byte for byte the output.", success)
+		}
+		t.Logf("\tTest: %d\tWhen setting `mask` and `noprint`.", 2)
+		{
+			var cfg struct {
+				DebugHost string `conf:"default:http://user:password@0.0.0.0:4000,mask,noprint"`
+			}
+			if err := conf.Parse(nil, "APP", &cfg); err != nil {
+				t.Logf("\t%s\tShould receive an error : %s", success, err)
+				return
+			} else {
+				t.Errorf("\t%s\tShould NOT succeed.", failed)
+			}
+		}
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -17,6 +17,7 @@ to customize the flag options.
 	noprint  - Denotes to not include the field in any display string.
 	required - Denotes a value must be provided.
 	help     - Provides a description for the help.
+	mask     - Denotes to mask the field value. If the value is a URL with scheme://user:password@, it will mask only the password
 
 The field name and any parent struct name will be used for the long form of
 the command name unless the name is overridden.

--- a/fields.go
+++ b/fields.go
@@ -32,6 +32,7 @@ type FieldOptions struct {
 	ShortFlagChar rune
 	Noprint       bool
 	Required      bool
+	Mask          bool
 }
 
 // extractFields uses reflection to examine the struct and generate the keys.
@@ -156,6 +157,8 @@ func parseTag(tagStr string) (FieldOptions, error) {
 				f.Noprint = true
 			case "required":
 				f.Required = true
+			case "mask":
+				f.Mask = true
 			}
 		case 2:
 			tagPropVal := strings.TrimSpace(vals[1])
@@ -186,6 +189,8 @@ func parseTag(tagStr string) (FieldOptions, error) {
 	switch {
 	case f.Required && f.DefaultVal != "":
 		return f, fmt.Errorf("cannot set both `required` and `default`")
+	case f.Mask && f.Noprint:
+		return f, fmt.Errorf("cannot set `mask` and `noprint`")
 	}
 
 	return f, nil


### PR DESCRIPTION
I was going through the Ultimate Service 2.0 course, and the `noprint` option is great to hide sensitive configuration fields, but as it removes both the key and the value, I think it can cause confusion if the option is actually _missing_ or meant to be hidden.

I attempted to create an additional option of `mask`, which keeps the key but masks the value. I also added a feature where if the value embeds a password in the URI _`scheme://username:password@host`_, then it would only mask the password and not the entire value.

In addition, as it wouldn't make sense to have `noprint` and `mask` together, I added a check for that as well.

Go `1.5` introduced [`url.Redacted`](https://github.com/golang/go/issues/34855) , but as the `go.mod` is pinned to `1.13` I have recreated the feature based on [this commit](https://github.com/nrxr/go/commit/46d06dbc4f9e30a57667bb8d0627bc1abed83bdc).

I am still new at writing tests in Go 😅  can you please review of the way I have written the test cases and suggest ways to improve them. 🙏 