### PR TITLE
Handle custom types

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -106,29 +106,22 @@ func extractFields(prefix []string, target interface{}) ([]Field, error) {
 			f = f.Elem()
 		}
 
-		switch {
+		if f.Kind() == reflect.Struct && setterFrom(f) == nil && textUnmarshaler(f) == nil && binaryUnmarshaler(f) == nil {
 
-		// If we've found a struct, drill down, appending fields as we go.
-		case f.Kind() == reflect.Struct:
-
-			// Skip if it can deserialize itself.
-			if setterFrom(f) == nil && textUnmarshaler(f) == nil && binaryUnmarshaler(f) == nil {
-
-				// Prefix for any subkeys is the fieldKey, unless it's
-				// anonymous, then it's just the prefix so far.
-				innerPrefix := fieldKey
-				if structField.Anonymous {
-					innerPrefix = prefix
-				}
-
-				embeddedPtr := f.Addr().Interface()
-				innerFields, err := extractFields(innerPrefix, embeddedPtr)
-				if err != nil {
-					return nil, err
-				}
-				fields = append(fields, innerFields...)
+			// Prefix for any subkeys is the fieldKey, unless it's
+			// anonymous, then it's just the prefix so far.
+			innerPrefix := fieldKey
+			if structField.Anonymous {
+				innerPrefix = prefix
 			}
-		default:
+
+			embeddedPtr := f.Addr().Interface()
+			innerFields, err := extractFields(innerPrefix, embeddedPtr)
+			if err != nil {
+				return nil, err
+			}
+			fields = append(fields, innerFields...)
+		} else {
 			envKey := fieldKey
 			if fieldOpts.EnvName != "" {
 				envKey = strings.Split(fieldOpts.EnvName, "_")

--- a/fields.go
+++ b/fields.go
@@ -106,8 +106,9 @@ func extractFields(prefix []string, target interface{}) ([]Field, error) {
 			f = f.Elem()
 		}
 
-		if f.Kind() == reflect.Struct && setterFrom(f) == nil && textUnmarshaler(f) == nil && binaryUnmarshaler(f) == nil {
-
+		switch {
+		// If we found a struct that can't deserialize itself, drill down, appending fields as we go.
+		case f.Kind() == reflect.Struct && setterFrom(f) == nil && textUnmarshaler(f) == nil && binaryUnmarshaler(f) == nil:
 			// Prefix for any subkeys is the fieldKey, unless it's
 			// anonymous, then it's just the prefix so far.
 			innerPrefix := fieldKey
@@ -121,7 +122,7 @@ func extractFields(prefix []string, target interface{}) ([]Field, error) {
 				return nil, err
 			}
 			fields = append(fields, innerFields...)
-		} else {
+		default:
 			envKey := fieldKey
 			if fieldOpts.EnvName != "" {
 				envKey = strings.Split(fieldOpts.EnvName, "_")


### PR DESCRIPTION
While using the library I noticed that custom types were essentially ignored, from both the output and the setting of the default values

Rummaging through the sources, I noticed that there actually was proper support for any type implementing `Setter`, `encoding.TextUnmarshaler` or `encoding.BinaryUnmarshaler`), but it was somehow blocked by the check done in `extractFields`, as it was hitting both "naked structs" and custom types based on structs

Not sure if I missed something obvious, but I had to perform this (little) change in order to add support for a custom value I wanted to use

Let me know if this makes sense to you: I also updated the tests to reflect the new handling of custom types