### PR TITLE
Ensure default value is applied after checking zero value

### DIFF
--- a/conf_test.go
+++ b/conf_test.go
@@ -942,6 +942,7 @@ a: Easy!
 b:
   c: 2
   d: [3, 4]
+c: 2000-01-01T10:17:00Z
 `
 
 type internal struct {
@@ -952,10 +953,13 @@ type internal struct {
 type yamlConfig struct {
 	A string
 	B internal
-	E string `conf:"default:postgres"`
+	E string    `conf:"default:postgres"`
+	C time.Time `conf:"default:2023-06-16T10:17:00Z"`
 }
 
 func TestYAML(t *testing.T) {
+	ts, _ := time.Parse(time.RFC3339, "2000-01-01T10:17:00Z")
+
 	tests := []struct {
 		name string
 		yaml []byte
@@ -968,21 +972,21 @@ func TestYAML(t *testing.T) {
 			[]byte(yamlData),
 			nil,
 			nil,
-			yamlConfig{A: "Easy!", B: internal{RenamedC: 2, D: []int{3, 4}}, E: "postgres"},
+			yamlConfig{A: "Easy!", B: internal{RenamedC: 2, D: []int{3, 4}}, E: "postgres", C: ts},
 		},
 		{
 			"env",
 			[]byte(yamlData),
 			map[string]string{"TEST_A": "EnvEasy!"},
 			nil,
-			yamlConfig{A: "EnvEasy!", B: internal{RenamedC: 2, D: []int{3, 4}}, E: "postgres"},
+			yamlConfig{A: "EnvEasy!", B: internal{RenamedC: 2, D: []int{3, 4}}, E: "postgres", C: ts},
 		},
 		{
 			"flag",
 			[]byte(yamlData),
 			nil,
 			[]string{"conf.test", "--a", "FlagEasy!"},
-			yamlConfig{A: "FlagEasy!", B: internal{RenamedC: 2, D: []int{3, 4}}, E: "postgres"},
+			yamlConfig{A: "FlagEasy!", B: internal{RenamedC: 2, D: []int{3, 4}}, E: "postgres", C: ts},
 		},
 	}
 

--- a/fields.go
+++ b/fields.go
@@ -258,20 +258,6 @@ func camelSplit(src string) []string {
 func processField(settingDefault bool, value string, field reflect.Value) error {
 	typ := field.Type()
 
-	// Look for a Set method.
-	setter := setterFrom(field)
-	if setter != nil {
-		return setter.Set(value)
-	}
-
-	if t := textUnmarshaler(field); t != nil {
-		return t.UnmarshalText([]byte(value))
-	}
-
-	if b := binaryUnmarshaler(field); b != nil {
-		return b.UnmarshalBinary([]byte(value))
-	}
-
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
 		if field.IsNil() {
@@ -284,6 +270,20 @@ func processField(settingDefault bool, value string, field reflect.Value) error 
 	// proper setting.
 	if settingDefault && !field.IsZero() {
 		return nil
+	}
+
+	// Look for a Set method.
+	setter := setterFrom(field)
+	if setter != nil {
+		return setter.Set(value)
+	}
+
+	if t := textUnmarshaler(field); t != nil {
+		return t.UnmarshalText([]byte(value))
+	}
+
+	if b := binaryUnmarshaler(field); b != nil {
+		return b.UnmarshalBinary([]byte(value))
 	}
 
 	switch typ.Kind() {


### PR DESCRIPTION
When a custom parser was used (ie: YAML) any field implementing `TextUnmarshaler` or `BinaryUnmarshaler` were overriden by their default value

This happened because the `!IsZero()` check was only made after trying to apply the default value with TextUnmarshaler/BinaryUnmarshaler, which ignored any existing value set by a custom parser.

I applied a simple fix by moving up the check, and updated the TestYAML test with a `time.Time` field