### PR TITLE
Added badge to pkg.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CircleCI](https://circleci.com/gh/ardanlabs/conf.svg?style=svg)](https://circleci.com/gh/ardanlabs/conf)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ardanlabs/conf/v3)](https://goreportcard.com/report/github.com/ardanlabs/conf/v3)
 [![go.mod Go version](https://img.shields.io/github/go-mod/go-version/ardanlabs/conf)](https://github.com/ardanlabs/conf)
+[![Go Reference](https://pkg.go.dev/badge/github.com/ardanlabs/conf/v3.svg)](https://pkg.go.dev/github.com/ardanlabs/conf/v3)
 
 Copyright 2018, 2019, 2020, 2021, Ardan Labs  
 hello@ardanlabs.com


### PR DESCRIPTION
Added a badge to pkg.dev on the top of the README.

Badge created using https://pkg.go.dev/badge/

This is how it looks on my fork:
![Screenshot_2023-08-21_15-23-33](https://github.com/ardanlabs/conf/assets/87697/f5f3f314-08bb-4eac-92e3-ea2a9b5b5289)

