### PR TITLE
fix: do not mask value for empty strings

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -103,6 +103,10 @@ func String(v interface{}) (string, error) {
 
 // maskVal masks an entire string or the user:password pair of a URL.
 func maskVal(v string) string {
+	if v == "" {
+		return ""
+	}
+
 	mask := "xxxxxx"
 	if u, err := url.Parse(v); err == nil {
 		userPass := u.User.String()


### PR DESCRIPTION
This changes the output of the following example code:

```go
package main

import (
	"fmt"

	"github.com/ardanlabs/conf/v3"
)

func main() {
	config := struct {
		Password string `conf:"mask"`
	}{}

	help, _ := conf.Parse("TEST", &config)

	s, _ := conf.String(&config)

	fmt.Println(help)
	fmt.Println("-----")
	fmt.Println(s)
}

```

from:

```console
$ go run . -h
Usage: example.com [options] [arguments]

OPTIONS
  --password/$TEST_PASSWORD  <string>  (default: xxxxxx)
  --help/-h                  
  display this help message

-----
--password=xxxxxx

```

to:
```console
$ go run . -h
Usage: example.com [options] [arguments]

OPTIONS
  --password/$TEST_PASSWORD  <string>  
  --help/-h                  
  display this help message

-----
--password=
```

Without this change it shows a masked default value and parsed configuration even it is not there. This leads to the assumption that the value is set, even it is not.