### PR TITLE
fix: update required check to account for Parser values. #40

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -230,7 +230,7 @@ func parse(args []string, namespace string, cfgStruct interface{}) error {
 		}
 
 		// If the field is marked 'required', check if no value was provided.
-		if field.Options.Required && !foundOverride {
+		if field.Options.Required && field.Field.IsZero() && !foundOverride {
 			return fmt.Errorf("required field %s is missing value", field.Name)
 		}
 	}


### PR DESCRIPTION
A possible solution for issue #40.

This would not work if the value provided by the Parser was the zero value.