### PR TITLE
fix!: usage formatting and cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Go 1.22
+          name: Install Go 1.23
           command: |
               sudo rm -rf /usr/local/go
-              wget -O go.tgz https://dl.google.com/go/go1.22.6.linux-amd64.tar.gz
+              wget -O go.tgz https://dl.google.com/go/go1.23.0.linux-amd64.tar.gz
               sudo tar -C /usr/local -xzf go.tgz
               which go
               go version

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,6 +20,7 @@
 
 # Please keep the list sorted.
 
+Alexander Yancharuk <alex@itvault.info>
 Andy Walker
 Arash Bina <arash@arash.io>
 Bruno Pereira <brunopereir4@gmail.com>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Conf
 
 [![CircleCI](https://circleci.com/gh/ardanlabs/conf.svg?style=svg)](https://circleci.com/gh/ardanlabs/conf)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ardanlabs/conf/v3)](https://goreportcard.com/report/github.com/ardanlabs/conf/v3)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ardanlabs/conf/v4)](https://goreportcard.com/report/github.com/ardanlabs/conf/v4)
 [![go.mod Go version](https://img.shields.io/github/go-mod/go-version/ardanlabs/conf)](https://github.com/ardanlabs/conf)
-[![Go Reference](https://pkg.go.dev/badge/github.com/ardanlabs/conf/v3.svg)](https://pkg.go.dev/github.com/ardanlabs/conf/v3)
+[![Go Reference](https://pkg.go.dev/badge/github.com/ardanlabs/conf/v4.svg)](https://pkg.go.dev/github.com/ardanlabs/conf/v4)
 
 Copyright 2018, 2019, 2020, 2021, Ardan Labs  
 hello@ardanlabs.com
@@ -29,4 +29,4 @@ limitations under the License.
 Package conf provides support for using environmental variables and command
 line arguments for configuration.
 
-All of the documentation can be found on the [go.dev](https://pkg.go.dev/github.com/ardanlabs/conf/v3?tab=doc) website.
+All of the documentation can be found on the [go.dev](https://pkg.go.dev/github.com/ardanlabs/conf/v4?tab=doc) website.

--- a/conf_test.go
+++ b/conf_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ardanlabs/conf/v3"
-	"github.com/ardanlabs/conf/v3/yaml"
+	"github.com/ardanlabs/conf/v4"
+	"github.com/ardanlabs/conf/v4/yaml"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/doc.go
+++ b/doc.go
@@ -27,19 +27,19 @@ the command name unless the name is overridden.
 
 # Example Usage
 
-As an example, using this config struct:
+As an example, using "APP" prefix and this config struct:
 
 	type ip struct {
-		Name string `conf:"default:localhost,env:IP_NAME_VAR"`
-		IP   string `conf:"default:127.0.0.0"`
+		Name string `conf:"default:localhost"`
+		IP   string `conf:"default:127.0.0.0,env:IP_VAR"`
 	}
 	type Embed struct {
 		Name     string        `conf:"default:bill"`
 		Duration time.Duration `conf:"default:1s,flag:e-dur,short:d"`
 	}
 	type config struct {
-		AnInt   int    `conf:"default:9"`
-		AString string `conf:"default:B,short:s"`
+		AnInt   map[string]int `conf:"default:min:0;max:9,help:map example"`
+		AString []string       `conf:"default:A;B;C,short:a,help:slice example"`
 		Bool    bool
 		Skip    string `conf:"-"`
 		IP      ip
@@ -48,21 +48,27 @@ As an example, using this config struct:
 
 The following usage information would be output you can display.
 
-Usage: conf.test [options] [arguments]
+Usage: conf.test [option...] [argument...]
 
 OPTIONS
+  -a, --a-string  <string>,[string...]  (default: A;B;C)        slice example
+      --an-int    <value>               (default: min:0;max:9)  map example
+      --bool      <bool>
+  -d, --e-dur     <duration>            (default: 1s)
+  -h, --help                                                    display this help message
+      --ip-ip     <string>              (default: 127.0.0.0)
+      --ip-name   <string>              (default: localhost)
+      --name      <string>              (default: bill)
+  -v, --version                                                 display version
 
-	--an-int/$CRUD_AN_INT         <int>       (default: 9)
-	--a-string/-s/$CRUD_A_STRING  <string>    (default: B)
-	--bool/$CRUD_BOOL             <bool>
-	--ip-name/$CRUD_IP_NAME_VAR   <string>    (default: localhost)
-	--ip-ip/$CRUD_IP_IP           <string>    (default: 127.0.0.0)
-	--name/$CRUD_NAME             <string>    (default: bill)
-	--e-dur/-d/$CRUD_DURATION     <duration>  (default: 1s)
-	--help/-h
-	display this help message
-	--version/-v
-	display version information
+ENVIRONMENT
+  APP_A_STRING  <string>,[string...]  (default: A;B;C)        slice example
+  APP_AN_INT    <value>               (default: min:0;max:9)  map example
+  APP_BOOL      <bool>
+  APP_DURATION  <duration>            (default: 1s)
+  APP_IP_VAR    <string>              (default: 127.0.0.0)
+  APP_IP_NAME   <string>              (default: localhost)
+  APP_NAME      <string>              (default: bill)
 
 # Example Parsing
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/ardanlabs/conf/v3
+module github.com/ardanlabs/conf/v4
 
-go 1.18
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.3.1
+	golang.org/x/text v0.23.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/sources.go
+++ b/sources.go
@@ -71,7 +71,7 @@ func envUsage(namespace string, fld Field) string {
 	if namespace == "" {
 		uspace = uspace[1:]
 	}
-	return "$" + uspace
+	return uspace
 }
 
 // =============================================================================
@@ -200,11 +200,15 @@ func (f *flag) Source(fld Field) (string, bool) {
 
 // flagUsage constructs a usage string for the flag argument.
 func flagUsage(fld Field) string {
-	usage := "--" + strings.ToLower(strings.Join(fld.FlagKey, `-`))
+	var usage string
+
 	if fld.Options.ShortFlagChar != 0 {
-		flagKey := []string{string(fld.Options.ShortFlagChar)}
-		usage += "/-" + strings.ToLower(strings.Join(flagKey, `-`))
+		usage += "-" + strings.ToLower(string(fld.Options.ShortFlagChar)) + ", "
+	} else {
+		usage += "    "
 	}
+
+	usage += "--" + strings.ToLower(strings.Join(fld.FlagKey, `-`))
 
 	return usage
 }

--- a/usage.go
+++ b/usage.go
@@ -7,10 +7,33 @@ import (
 	"reflect"
 	"strings"
 	"text/tabwriter"
+
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
 )
 
-const buildKey = `Build`
-const descKey = `Desc`
+const (
+	buildKey   = "Build"
+	descKey    = "Desc"
+	helpKey    = "help"
+	versionKey = "version"
+)
+
+type sortedFields struct {
+	fields []Field
+}
+
+func (sf sortedFields) Len() int {
+	return len(sf.fields)
+}
+
+func (sf sortedFields) Swap(i, j int) {
+	sf.fields[i], sf.fields[j] = sf.fields[j], sf.fields[i]
+}
+
+func (sf sortedFields) Bytes(i int) []byte {
+	return []byte(strings.ToLower(strings.Join(sf.fields[i].FlagKey, `-`)))
+}
 
 func containsField(fields []Field, name string) bool {
 	for i := range fields {
@@ -42,17 +65,30 @@ func fmtUsage(namespace string, fields []Field) string {
 			FlagKey:   []string{"version"},
 			Options: FieldOptions{
 				ShortFlagChar: 'v',
-				Help:          "display version information",
+				Help:          "display version",
 			}})
 	}
 
-	_, file := path.Split(os.Args[0])
-	fmt.Fprintf(&sb, "Usage: %s [options] [arguments]\n\n", file)
+	sf := sortedFields{fields: fields}
+	cc := collate.New(language.English)
+	cc.Sort(sf)
 
-	fmt.Fprintln(&sb, "OPTIONS")
+	_, file := path.Split(os.Args[0])
+	fmt.Fprintf(&sb, "Usage: %s [option...] [argument...]\n\n", file)
+
 	w := new(tabwriter.Writer)
 	w.Init(&sb, 0, 4, 2, ' ', tabwriter.TabIndent)
 
+	fmt.Fprintln(&sb, "OPTIONS")
+	writeOptions(w, sf.fields)
+
+	fmt.Fprintln(&sb, "ENVIRONMENT")
+	writeEnv(w, namespace, sf.fields)
+
+	return sb.String()
+}
+
+func writeOptions(w *tabwriter.Writer, fields []Field) {
 	for _, fld := range fields {
 
 		// Skip printing usage info for fields that just hold arguments.
@@ -67,28 +103,55 @@ func fmtUsage(namespace string, fields []Field) string {
 
 		fmt.Fprintf(w, "  %s", flagUsage(fld))
 
-		// Do not display env vars for help since they aren't respected.
-		if fld.Name != "help" && fld.Name != "version" {
-			fmt.Fprintf(w, "/%s", envUsage(namespace, fld))
-		}
-
 		typeName, help := getTypeAndHelp(&fld)
 
 		// Do not display type info for help because it would show <bool> but our
 		// parsing does not really treat --help as a boolean field. Its presence
 		// always indicates true even if they do --help=false.
-		if fld.Name != "help" && fld.Name != "version" {
+		if fld.Name != helpKey && fld.Name != versionKey {
 			fmt.Fprintf(w, "\t%s", typeName)
+			fmt.Fprintf(w, "\t%s", getOptString(fld))
+		} else {
+			fmt.Fprint(w, "\t\t")
 		}
 
-		fmt.Fprintf(w, "\t%s\n", getOptString(fld))
-		if help != "" {
-			fmt.Fprintf(w, "  %s\n", help)
+		fmt.Fprintf(w, "\t%s", help)
+
+		fmt.Fprint(w, "\n")
+	}
+
+	fmt.Fprint(w, "\n")
+	w.Flush()
+}
+
+func writeEnv(w *tabwriter.Writer, namespace string, fields []Field) {
+	for _, fld := range fields {
+
+		// Skip printing usage info for fields that just hold arguments.
+		if fld.Field.Type() == argsT {
+			continue
 		}
+
+		// Do not display version fields and Description
+		// Do not display env vars for help since they aren't respected.
+		if fld.Name == buildKey || fld.Name == descKey ||
+			fld.Name == helpKey || fld.Name == versionKey {
+			continue
+		}
+
+		fmt.Fprintf(w, "  %s", envUsage(namespace, fld))
+
+		typeName, help := getTypeAndHelp(&fld)
+
+		fmt.Fprintf(w, "\t%s", typeName)
+		fmt.Fprintf(w, "\t%s", getOptString(fld))
+
+		fmt.Fprintf(w, "\t%s", help)
+
+		fmt.Fprint(w, "\n")
 	}
 
 	w.Flush()
-	return sb.String()
 }
 
 // getTypeAndHelp extracts the type and help message for a single field for


### PR DESCRIPTION
* Split options and environment variables in usage output.

* Alphabetic options order in usage output.

* Update documentation for new usage output.

* Update documentation with slice, map and custom help examples.

BREAKING CHANGE: go.mod updated to 1.23 and v4 for this deps:
  "golang.org/x/text/collate"
  "golang.org/x/text/language"
  Builds using Go 1.21, 1.22 may be broken.