### PR TITLE
ci: Add check for push and PR to master events

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,56 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+  pull_request_target:
+    branches: [ "master" ]
+
+env:
+  GO_VERSION: '1.23.0'
+
+jobs:
+  checks:
+    name: checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: 'go.sum'
+      - name: Run Download
+        run: go mod download
+
+      - name: Run vet
+        run: CGO_ENABLED=0 go vet ./...
+
+      - name: Run staticheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          staticcheck -checks=all ./...
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck -show verbose ./...
+
+  tests:
+    name: tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ oldstable, stable ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: 'go.sum'
+          go-version: ${{ matrix.go-version }}
+
+      - name: Run tests
+        run: go test -race ./...


### PR DESCRIPTION
All CI checks ported to github actions for ability to validate PR before merge to master.
According to [this doc section](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/approving-workflow-runs-from-public-forks#approving-workflow-runs-on-a-pull-request-from-a-public-fork) maintainer with write access now can run actions before merge.