### PR TITLE
fix for required value in yaml file

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -248,7 +248,7 @@ func parse(args []string, namespace string, cfgStruct interface{}) error {
 		}
 
 		// If the field is marked 'required', check if no value was provided.
-		if field.Options.Required && !foundOverride {
+		if field.Options.Required && !foundOverride && field.Field.IsZero() {
 			return fmt.Errorf("required field %s is missing value", field.Name)
 		}
 	}

--- a/conf_test.go
+++ b/conf_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/ardanlabs/conf/v3"
 	"github.com/ardanlabs/conf/v3/yaml"
-	"github.com/google/go-cmp/cmp"
 )
 
 const (
@@ -1171,6 +1172,14 @@ b:
   d: [3, 4]
 g: 2000-01-01T10:17:00Z
 `
+var yamlData33 = `
+a: Easy!
+b:
+  c: 2
+  d: [3, 4]
+g: 2000-01-01T10:17:00Z
+i: 2023-06-16T10:17:00Z
+`
 
 type yamlConfig3 struct {
 	A string
@@ -1232,6 +1241,14 @@ func TestYAML(t *testing.T) {
 			nil,
 			&yamlConfig3{},
 			errors.New("parsing config: required field I is missing value"),
+		},
+		{
+			"required with value in yaml",
+			[]byte(yamlData33),
+			nil,
+			nil,
+			&yamlConfig3{},
+			&yamlConfig3{A: "Easy!", B: internal{RenamedC: 2, D: []int{3, 4}}, E: "postgres", F: dTS, G: oTS, I: dTS},
 		},
 	}
 


### PR DESCRIPTION
This fix makes it possible to have a required field in yaml. Currently it fails and says required value is missing even though it does exist in yaml file.